### PR TITLE
Ajout système KEY + FILL

### DIFF
--- a/projet_esiee_2021/Projet_IMA/Parallelepipede3D.cs
+++ b/projet_esiee_2021/Projet_IMA/Parallelepipede3D.cs
@@ -12,7 +12,7 @@ namespace Projet_IMA
         public V3 m_Hauteur { get; set; }
         public V3 m_Origine { get; set; }
 
-        public Parallelepipede3D(V3 centre, V3 longueur, V3 largeur, V3 hauteur, Lumiere lumiere, Texture texture, Texture bump_texture ,float coefficient_diffus = 0.006f, float coefficient_speculaire = .0001f, float puissance_speculaire = 60, float coefficient_bumpmap=.005f) : base(centre, lumiere, texture, bump_texture, coefficient_diffus, coefficient_speculaire, puissance_speculaire, coefficient_bumpmap)
+        public Parallelepipede3D(V3 centre, V3 longueur, V3 largeur, V3 hauteur, Lumiere key_lumiere, Lumiere fill_lumiere, Texture texture, Texture bump_texture ,float coefficient_diffus = 0.006f, float coefficient_speculaire = .0001f, float puissance_speculaire = 60, float coefficient_bumpmap=.005f) : base(centre, key_lumiere, fill_lumiere, texture, bump_texture, coefficient_diffus, coefficient_speculaire, puissance_speculaire, coefficient_bumpmap)
         {
             m_Longueur = longueur;
             m_Largeur = largeur;

--- a/projet_esiee_2021/Projet_IMA/ProjetEleve.cs
+++ b/projet_esiee_2021/Projet_IMA/ProjetEleve.cs
@@ -12,8 +12,9 @@ namespace Projet_IMA
         {
             Texture texture = new Texture("gold.jpg");
             Texture bump_texture = new Texture("bump38.jpg");
-            Lumiere lumiere = new Lumiere(new V3(1, -1, 1), new Couleur(140, 140, 140));
-            Sphere3D SphereA = new Sphere3D(new V3(200, 200, 300), 150, lumiere, texture, bump_texture);
+            Lumiere key_lumiere = new Lumiere(new V3(1, -.8f, 0), new Couleur(255, 255, 255)*.7f);
+            Lumiere fill_lumiere = new Lumiere(new V3(-1, -.8f, 0), new Couleur(255, 255, 255) * .3f);
+            Sphere3D SphereA = new Sphere3D(new V3(200, 200, 300), 150, key_lumiere, fill_lumiere, texture, bump_texture);
             SphereA.Draw();
         }
     }

--- a/projet_esiee_2021/Projet_IMA/Sphere3D.cs
+++ b/projet_esiee_2021/Projet_IMA/Sphere3D.cs
@@ -9,7 +9,7 @@ namespace Projet_IMA
     {
         public float m_Rayon { get; set; }
 
-        public Sphere3D(V3 centre, float rayon,  Lumiere lumiere,Texture texture, Texture bump_texture, float coefficient_diffus = .006f, float coefficient_speculaire = .0001f, float puissance_speculaire=60, float coefficient_bumpmap=.005f) : base(centre, lumiere, texture, bump_texture, coefficient_diffus, coefficient_speculaire, puissance_speculaire, coefficient_bumpmap)
+        public Sphere3D(V3 centre, float rayon,  Lumiere key_lumiere, Lumiere fill_lumiere,Texture texture, Texture bump_texture, float coefficient_diffus = .005f, float coefficient_speculaire = .00005f, float puissance_speculaire=60, float coefficient_bumpmap=.005f) : base(centre, key_lumiere, fill_lumiere, texture, bump_texture, coefficient_diffus, coefficient_speculaire, puissance_speculaire, coefficient_bumpmap)
         {
             this.m_Rayon = rayon;
         }
@@ -48,7 +48,7 @@ namespace Projet_IMA
                     int x_ecran = (int)(PixelPosition.x);
                     int y_ecran = (int)(PixelPosition.z);
 
-                    BitmapEcran.DrawPixel(x_ecran, y_ecran, getCouleur(PixelPosition,u,v,dMdu,dMdv));
+                    BitmapEcran.DrawPixel(x_ecran, y_ecran, getCouleur(this.m_FillLumiere,PixelPosition,u,v,dMdu,dMdv)+ getCouleur(this.m_KeyLumiere, PixelPosition, u, v, dMdu, dMdv));
                 }
             }
         }


### PR DESCRIPTION
• Ajout d'une nouvelle lampe qui éclaire la sphère sur la gauche à 30% (FILL light) tandis que la lampe de base sur la droite devient notre KEY light et l'éclaire à 70%.

• Backlight peut-être à rajouter plus tard mais pas nécessaire sur une sphère

• Cela veut dire que les Objet3D disposent maintenant de deux attributs lumière au lieu d'un auparavant, il y a l'attribut "m_KeyLumiere" et l'attribut "m_KeyLumiere" qui correspondent à nos deux nouvelles sources de lumière

• Les fonctions qui calculent la couleur de chaque pixel d'un Objet3D prennent désormais une lumière en paramètre, au lieu de prendre la lumière principale. Cela veut donc dire qu'on calcule la couleur d'abord avec la key light, puis avec la fill light et nous additionnons le résultat des deux.